### PR TITLE
fix link target for 'JSON Schema' draft v4

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,11 @@
-# json-schema-parser
-
 [![CircleCI](https://circleci.com/gh/VoxSupplyChain/json-schema-parser.svg?style=svg)](https://circleci.com/gh/VoxSupplyChain/json-schema-parser)
 
 JSON-Schema v4 parser and Schema validator implemented in Scala.
 
 Features:
 
- * Implementation of [Schema v4](http://json-schema.org/latest/json-schema-core.html) and [Schema Validator v4](http://json-schema.org/latest/json-schema-validation.html)
- * both [canonical and inline dereferencing](http://json-schema.org/latest/json-schema-core.html#anchor30)
+ * Implementation of [Schema v4][draft-zyp-json-schema-04] and [Schema Validator v4][draft-fge-json-schema-validation-00]
+ * both [canonical and inline dereferencing][draft-zyp-json-schema-04#7.2.3]
  * supports scope overriding via id fields, and dereferrencing according the custom scopes.
  * expands ids to absolute uris
  * results in Schema tree
@@ -39,9 +37,9 @@ $ java -jar target/scala-2.10/json-schema-parser-assembly-0.11.0.jar <schema-uri
  
 ### Reference
 
- * http://json-schema.org/latest/json-schema-core.html
- * http://json-schema.org/latest/json-schema-validation.html
- 
+ * [JSON Schema Core (Draft 4)][draft-zyp-json-schema-04]
+ * [JSON Schema Validation ('Draft 4')][draft-fge-json-schema-validation-00] (actually published as I-D version 0 but extracted from JSON Schema Core from Draft 3 to Draft 4)
+
 ### Used in
 
  * https://github.com/VoxSupplyChain/json-schema-codegen
@@ -50,3 +48,7 @@ $ java -jar target/scala-2.10/json-schema-parser-assembly-0.11.0.jar <schema-uri
 
  * 0.11.0
   * #1 support for cyclic references (@blast-hardcheese)
+
+[draft-zyp-json-schema-04]: https://tools.ietf.org/html/draft-zyp-json-schema-04
+[draft-zyp-json-schema-04#7.2.3]: https://tools.ietf.org/html/draft-zyp-json-schema-04#section-7.2.3
+[draft-fge-json-schema-validation-00]: https://tools.ietf.org/html/draft-fge-json-schema-validation-00


### PR DESCRIPTION
The latest version of 'JSON Schema Core' is currently a link
to [1] and for 'JSON Schema Validation' to [2].

> The latest Internet-Draft at the IETF is v5, published 2016-10-13.
> (Due to a change in authorship the I-D numbering has been reset).

Update to IETF draft v4 until json-schema-org/json-schema-org.github.io#59
has been fixed.

[1]: https://tools.ietf.org/html/draft-wright-json-schema-00
[2]: https://tools.ietf.org/html/draft-wright-json-schema-validation-00